### PR TITLE
docs: LOE POC guide (CLAUDE.md, .clinerules.md, docs/)

### DIFF
--- a/.clinerules.md
+++ b/.clinerules.md
@@ -1,0 +1,28 @@
+# Project Rules for AI Assistants
+
+## Repo has two concerns
+- **AWS COG conversion** (primary): `lib/`, top-level `*_cog*.py` / `*nodata*.py` scripts,
+  `templates/` notebooks. GDAL/rasterio.
+- **LOE/FTE capacity-report POC**: `loe-poc/`, `.github/scripts/generate_loe_report.py`,
+  `.github/workflows/loe-report.yml`. See `docs/LOE_POC.md`.
+
+## LOE POC gotchas (don't relearn the hard way)
+- PI + Start/End dates = **project-board fields**; the LOE/FTE table = **issue body**. The
+  report reads `gh project item-list` (board → issue), never the issue's Projects sidebar.
+- POC board `kyle-lesinger/projects/1` is a **personal** project → it does **not** show in
+  org-repo issue sidebars. Membership is real; confirm via `item-list`, not the issue page.
+- Action secret **`PROJECT_TOKEN`** = classic PAT `repo` + `read:org` + `project`.
+  `unknown owner type` ⇒ missing `read:org`. `GITHUB_TOKEN` cannot read Projects v2.
+- `main` is **protected** — never push reports to it. Reports go to **`loe-report/<pi>`**
+  branches (else `GH006`).
+- Program Increment is a **single-select** on the POC board (iteration fields aren't
+  API-creatable); the parser handles both single-select and iteration PI values.
+- `.gitignore` ignores `*.csv` / `*.json` globally — keep the `!reports/*.csv` and
+  `!loe-poc/*.json` negations or reports won't commit.
+- Demo issues **#10–#59** (`poc-loe`); clean up with `loe-poc/cleanup_issues.py`, not by hand.
+- **No Jules yet** — keep report output deterministic (seeded, stable ordering) so future
+  run-diffs stay meaningful.
+
+## General
+- Absolute paths in code; relative paths when referencing files to users.
+- Batch independent tool calls; validate changes with proof before claiming done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# Project Guide
+
+## What this repo is
+Two concerns share this repo:
+1. **AWS COG conversion** (primary): convert GeoTIFFs → Cloud-Optimized GeoTIFFs, fix
+   nodata, reproject, upload to S3. Code in `lib/` (core / analysis / processors), top-level
+   scripts (`update_nodata_cog.py`, `convert_nodata_to_zero.py`, `check_nodata.py`), and
+   notebooks in `templates/`. GDAL/rasterio based.
+2. **LOE/FTE capacity-report POC** (added this session): a GitHub Action that reads team
+   **Objective** issues + a **Projects v2** board and reports staffing capacity per Program
+   Increment. Code in `loe-poc/`, `.github/scripts/generate_loe_report.py`,
+   `.github/workflows/loe-report.yml`. Full detail in `docs/LOE_POC.md`.
+
+## LOE POC — critical, non-obvious constraints
+- **Data split:** PI and each objective's **Start/End dates come from the project board**
+  (fields), **not** the issue body. The **LOE/FTE table lives in the issue body**. The report
+  joins them.
+- **Board is read, not issues:** the Action calls `gh project item-list` (board → issue),
+  never the issue's Projects sidebar.
+- **POC board is a personal project** (`kyle-lesinger/projects/1`). Consequence: org-repo
+  issues **do not display** it in their "Projects" sidebar (user-project ↔ org-repo-issue is
+  one-directional in the UI). The membership is real — verify with `gh project item-list`,
+  not the issue page.
+- **CI token:** the Action needs repo secret **`PROJECT_TOKEN`** = a **classic** PAT with
+  **`repo` + `read:org` + `project`**. The default `GITHUB_TOKEN` cannot read Projects v2.
+  `unknown owner type` from `gh project` ⇒ the token is missing `read:org`.
+- **`main` is protected** (PRs required). The Action does **not** push reports to `main`; it
+  publishes each run to a **per-PI branch `loe-report/<pi>`** (commits accumulate; open a PR
+  to keep a snapshot). Pushing reports to main fails with `GH006`.
+- **Iteration fields aren't API-creatable**, so the POC board models **Program Increment as a
+  single-select** (`PI 26.4`, `PI 27.2`); the parser also handles the real org board's
+  **iteration** PI field. Single-select PI windows come from `PI_WINDOWS` in the parser.
+- **`.gitignore` globally ignores `*.csv` / `*.json`** — the negations `!reports/*.csv` and
+  `!loe-poc/*.json` keep report + tracking files tracked. `git add reports` (local and in CI)
+  depends on these.
+- **No Jules integration yet.** The report is deterministic (seeded generator + stable
+  ordering) specifically as the hook point for future Jules run-diffing.
+
+## Run / test (LOE)
+- Offline (no network): `python loe-poc/generate_sample_issues.py && python
+  .github/scripts/generate_loe_report.py --issues-json loe-poc/sample_issues.json
+  --out-dir reports --now "$(date -u +%FT%TZ)"`
+- Against the board: `gh project item-list 1 --owner kyle-lesinger --format json --limit 800
+  > items.json && python .github/scripts/generate_loe_report.py --project-json items.json
+  --pi "PI 26.4" --out-dir reports --now "$(date -u +%FT%TZ)"`
+- Manual Action: **Actions → LOE Capacity Report → Run workflow →** pick PI
+  (All / PI 26.4 / PI 27.2) → report lands on `loe-report/<pi>`.
+
+## Demo data + cleanup
+50 demo issues **#10–#59** (labels `Objective`, `poc-loe`) tracked in
+`loe-poc/created_issues.json`; board item ids in `loe-poc/project_items.json`. Cleanup:
+`python loe-poc/cleanup_issues.py --delete` then `gh project delete 1 --owner kyle-lesinger`.
+
+## Capacity rules / roles
+Roles are a fixed set: PM, Frontend, Backend, Geospatial, Data Curator, Comms, ML, Designer,
+Jupyterhub (other roles / non-numeric FTE → row skipped + warned). Raw FTE summed per person
+**per PI** > 1.0 = **over-allocated**; **weighted FTE** = fte × (objective days in PI / PI
+days) for partial-window objectives (informational; the flag uses the raw sum).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,46 @@
+# Architectural Decisions
+
+Short decision records. Newest first. Scope: LOE/FTE capacity-report POC.
+
+## ADR-8: `.gitignore` negations for report + tracking files
+The repo globally ignores `*.csv` and `*.json`. Report CSVs and the demo tracking JSONs must
+be committed (and the Action commits `reports/`), so `!reports/*.csv` and `!loe-poc/*.json`
+were added. **Load-bearing** — removing them breaks report commits locally and in CI.
+
+## ADR-7: No Jules integration (yet)
+Jules is a stated future goal but is **not** wired in. Instead the report is made
+**deterministic** (seeded generator, stable ordering, rounded weighted FTE) so a future Jules
+job can diff `loe-report/<pi>` across runs. Keep output deterministic.
+
+## ADR-6: Over-allocation flagged on the raw per-PI FTE sum
+User rule: "sum the FTE… not more than 1 per PI." Flag = raw Σ FTE per person per PI > 1.0.
+**Weighted FTE** (fte × fraction of PI covered) is reported alongside as the time-averaged
+view but does **not** drive the flag.
+
+## ADR-5: PI naming left as `PI 27.2` (not renamed to 27.1)
+The real board's next iteration is literally `PI 27.2`. A rename to `27.1` was considered and
+explicitly declined by the user ("too much work"). POC board + parser + workflow all use
+`PI 26.4` and `PI 27.2`.
+
+## ADR-4: `PROJECT_TOKEN` (classic PAT) for CI
+The default `GITHUB_TOKEN` cannot read org/user Projects v2 boards. The Action reads the board
+with a repo secret `PROJECT_TOKEN` = classic PAT with `repo` + `read:org` + `project`.
+`read:org` is required or `gh project` fails with `unknown owner type`.
+
+## ADR-3: Reports publish to per-PI branches, not `main`
+`main` is protected (PRs required), so the Action's `git push` of the report was rejected
+(`GH006`). Each run now commits the report to `loe-report/<pi>` (commits accumulate); open a
+PR to `main` to keep a snapshot. This also keeps report churn out of main history.
+
+## ADR-2: Program Increment modeled as single-select on the POC board
+Projects v2 **iteration** fields cannot be created via the API (`gh project field-create`
+supports only TEXT/SINGLE_SELECT/DATE/NUMBER). The POC board uses a single-select PI; the
+parser normalizes both single-select (window via `PI_WINDOWS`) and iteration (window intrinsic)
+so it works against the POC board now and the real org board later.
+
+## ADR-1: Separate throwaway POC project, not the live org board
+The real Disasters Learning Portal board (**#5**) has ~298 live items across org repos. To
+avoid polluting it, the POC uses a personal throwaway board (`kyle-lesinger/projects/1`).
+**Consequence:** org-repo issues do not show a user-owned project in their sidebar, so the 50
+demo issues display "No projects" even though they are on the board. Switch to an org board to
+change that.

--- a/docs/LOE_POC.md
+++ b/docs/LOE_POC.md
@@ -1,0 +1,90 @@
+# LOE / FTE Capacity Report — POC
+
+Report team staffing capacity from GitHub **Objective** issues + a **Projects v2** board.
+FTE is summed per person **per Program Increment (PI)**; > 1.0 = over-allocated. A duration
+**weighted FTE** adjusts for objectives that cover only part of a PI.
+
+## Data model
+- **Issue body** holds the `## LOE/FTE` markdown table: `| Person | Role | FTE | Notes |`.
+  Roles are a fixed set (PM, Frontend, Backend, Geospatial, Data Curator, Comms, ML, Designer,
+  Jupyterhub). Rows with any other role or non-numeric FTE are skipped and warned.
+- **Project board fields** hold **Program Increment** (which PI) and **Start Date / End Date**
+  (the objective's own window inside the PI). These are deliberately **not** in the issue body.
+- **PI window**: on the real org board (`Disasters-Learning-Portal` project **#5**) PI is an
+  **iteration** field (window = `startDate` + `duration`). On the POC board it is a
+  **single-select**, so the window is looked up from `PI_WINDOWS` in the parser. The parser
+  normalizes both shapes.
+
+## Components
+| File | Role |
+| --- | --- |
+| `.github/scripts/generate_loe_report.py` | Parser + report generator (stdlib only). Inputs: `--project-json` (board), `--issues-json` (offline sample), `--from-dir` (md fixtures). `--pi "PI 26.4"` filter. Writes `reports/loe_allocations.csv`, `loe_by_person.csv`, `loe_by_role.csv`, `loe_summary.md`. |
+| `.github/workflows/loe-report.yml` | The Action. `workflow_dispatch` PI dropdown; reads board via `gh project item-list`; publishes report to `loe-report/<pi>` branch; run summary + artifact. |
+| `.github/ISSUE_TEMPLATE/objective.md` | Objective issue template (LOE table only; a note says PI/dates go on the board). |
+| `loe-poc/generate_sample_issues.py` | Seeded generator → `loe-poc/sample_issues.json` (issue body + a `project` block with PI/dates). |
+| `loe-poc/create_issues.py` | Opens the demo issues via `gh`; records `loe-poc/created_issues.json`. |
+| `loe-poc/setup_project.py` | Adds issues to the board + sets PI/Start/End fields. Resumable/idempotent (reuses existing board items; retries transient errors); records `loe-poc/project_items.json`. |
+| `loe-poc/cleanup_issues.py` | Closes/deletes the demo issues (by tracking file or `poc-loe` label). |
+
+## Data flow (the Action)
+1. `gh project item-list <n> --owner <owner> --format json` → all board items.
+2. Keep items whose issue **title contains "objective"**.
+3. Per item: PI + window (iteration, or single-select + `PI_WINDOWS` lookup), objective
+   Start/End (board date fields), and the LOE table (issue body).
+4. Aggregate per `(PI, person)` and `(PI, role)`; compute raw + weighted FTE.
+5. Emit CSVs + `loe_summary.md` (with clickable `[#N](url)` ticket links).
+6. Commit to `loe-report/<pi>`, upload artifact, append summary to the run.
+
+**Reconciliation invariant** (tested): Σ allocation FTE == Σ by_person == Σ by_role, per PI,
+for both raw and weighted (weighted is rounded per-allocation so it reconciles to the cent).
+
+## Current deployment state
+- POC board: **`kyle-lesinger/projects/1`** (id `PVT_kwHOC5zXJc4Bd9S1`). Fields: **Program
+  Increment** (single-select: `PI 26.4`, `PI 27.2`), **Start Date**, **End Date** (DATE).
+- Demo issues **#10–#59** in `Disasters-Learning-Portal/disasters-aws-conversion`, labels
+  `Objective` + `poc-loe`. (Objective numbers 1–50 map to issues 10–59 in creation order.)
+- Repo secret **`PROJECT_TOKEN`** set (classic PAT `repo` + `read:org` + `project`).
+- Reports publish to **`loe-report/<pi>`** branches (e.g. `loe-report/PI-26.4`,
+  `loe-report/PI-27.2`, `loe-report/all-pis`). `main` is never written by the Action.
+
+## Gotchas (with rationale)
+- **Personal POC board ⇒ "No projects" on issues.** GitHub does not surface user-owned
+  project membership in an org-repo issue's sidebar. Chosen deliberately to avoid polluting
+  the live org board (#5 has ~298 real items). To make the sidebar show it, use an org board.
+- **`unknown owner type`** from `gh project` = token missing `read:org`.
+- **`GITHUB_TOKEN` can't read Projects v2** → the Action must use `PROJECT_TOKEN`.
+- **`main` protected** → reports go to per-PI branches, not main (`GH006` otherwise).
+- **Iteration fields aren't API-creatable** → POC PI is single-select; parser handles both.
+- **`.gitignore` ignores `*.csv`/`*.json`** → negations `!reports/*.csv` / `!loe-poc/*.json`
+  are load-bearing for committing reports.
+
+## Run / cleanup
+```bash
+# offline
+python loe-poc/generate_sample_issues.py
+python .github/scripts/generate_loe_report.py --issues-json loe-poc/sample_issues.json \
+  --out-dir reports --now "$(date -u +%FT%TZ)"
+
+# against the board
+gh project item-list 1 --owner kyle-lesinger --format json --limit 800 > items.json
+python .github/scripts/generate_loe_report.py --project-json items.json --pi "PI 26.4" \
+  --out-dir reports --now "$(date -u +%FT%TZ)"
+
+# full demo from scratch
+gh label create Objective --color 1d76db --force
+gh label create poc-loe   --color 5319e7 --force
+python loe-poc/create_issues.py
+python loe-poc/setup_project.py
+
+# cleanup
+python loe-poc/cleanup_issues.py --delete
+gh project delete 1 --owner kyle-lesinger
+```
+
+## Future
+- **Jules** (not built): the report is deterministic on purpose. A future job would diff
+  `loe-report/<pi>` across runs to flag new over-allocations, FTE drift, added/removed
+  objectives.
+- **Org board**: point `POC_PROJECT_OWNER` / `POC_PROJECT_NUMBER` (workflow) and
+  `loe-poc/setup_project.py` at the org board (**#5**, owner `Disasters-Learning-Portal`) so
+  issues show the project in their sidebar. #5's PI is an iteration field (already supported).


### PR DESCRIPTION
Adds AI-assistant + developer docs for the LOE capacity POC: overview, architecture (docs/LOE_POC.md), and 8 ADRs (docs/DECISIONS.md). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)