### PR TITLE
LOE Action: drop [skip ci] so Netlify builds the report PR preview

### DIFF
--- a/.github/workflows/loe-report.yml
+++ b/.github/workflows/loe-report.yml
@@ -122,7 +122,9 @@ jobs:
           if git diff --cached --quiet; then
             echo "No report changes for $BR."
           else
-            git commit -m "LOE report — ${{ steps.cfg.outputs.label }} (run ${{ github.run_id }}) [skip ci]"
+            # No [skip ci]: this workflow has no push trigger (so the commit can't loop it),
+            # and Netlify honors [skip ci] by canceling the Deploy Preview we want on the PR.
+            git commit -m "LOE report — ${{ steps.cfg.outputs.label }} (run ${{ github.run_id }})"
             git push origin "$BR"
             echo "Report pushed to branch: $BR"
           fi


### PR DESCRIPTION
Netlify honors `[skip ci]` and was canceling the Deploy Preview on the report PR (#69). The workflow has no `push` trigger, so the tag was unnecessary. Removing it lets each report commit build a dashboard preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)