### PR TITLE
LOE report — all PIs

### DIFF
--- a/reports/loe_summary.md
+++ b/reports/loe_summary.md
@@ -1,6 +1,6 @@
 # LOE / FTE Capacity Report
 
-_Generated: 2026-07-21T01:36:32Z_
+_Generated: 2026-07-21T01:51:56Z_
 _Raw FTE summed per person **per PI**; > 1.0 = over-allocated. Weighted FTE adjusts for objectives that cover only part of the PI._
 
 ## Headline

--- a/reports/loe_summary.md
+++ b/reports/loe_summary.md
@@ -1,6 +1,6 @@
 # LOE / FTE Capacity Report
 
-_Generated: 2026-07-21T01:51:56Z_
+_Generated: 2026-07-21T01:58:16Z_
 _Raw FTE summed per person **per PI**; > 1.0 = over-allocated. Weighted FTE adjusts for objectives that cover only part of the PI._
 
 ## Headline

--- a/reports/loe_summary.md
+++ b/reports/loe_summary.md
@@ -1,6 +1,6 @@
 # LOE / FTE Capacity Report
 
-_Generated: 2026-07-21T01:58:16Z_
+_Generated: 2026-07-21T01:59:35Z_
 _Raw FTE summed per person **per PI**; > 1.0 = over-allocated. Weighted FTE adjusts for objectives that cover only part of the PI._
 
 ## Headline

--- a/reports/loe_summary.md
+++ b/reports/loe_summary.md
@@ -1,6 +1,6 @@
 # LOE / FTE Capacity Report
 
-_Generated: 2026-07-20T00:00:00Z_
+_Generated: 2026-07-21T01:36:32Z_
 _Raw FTE summed per person **per PI**; > 1.0 = over-allocated. Weighted FTE adjusts for objectives that cover only part of the PI._
 
 ## Headline


### PR DESCRIPTION
Automated LOE/FTE capacity report for **all PIs**.

📊 **Dashboard:** https://veda-fte-test.netlify.app — interactive view of the latest all-PIs report (over-allocation, per-person / per-role FTE, and in-browser what-if editing). It reads the report data live, so it always reflects the newest run.

Report files are in `reports/` on this branch. Merge to snapshot this report into `main`, or leave open as a living view.